### PR TITLE
Clarification on X.FL connectors

### DIFF
--- a/source/Hardware Guide/Headstages/tethers.rst
+++ b/source/Hardware Guide/Headstages/tethers.rst
@@ -69,7 +69,7 @@ Headstage Side
 __________________________
 
 Required Tools and Materials
-    - Solder jig: A copper-clad board with X.FL connectors soldered to it
+    - Solder jig: A copper-clad board with X.FL connectors (`X.FL-R-SMT-1(80) <https://www.hirose.com/en/product/p/CL0331-0701-8-80>`__) soldered to it
       to that hold X.FL sockets in place during soldering.
     - 5-minute epoxy
     - Small and sharp wire cutters
@@ -82,7 +82,7 @@ Required Tools and Materials
 
 Cable Components
     - Coaxial cable segment (these instructions uses Axon Cable PCX40K10AK)
-    - Hirose X.FL-PR-SMT1-2(80) X.FL coaxial socket
+    - Hirose `X.FL-PR-SMT1-2(80) <https://www.hirose.com/product/p/CL0331-0713-7-80>`__ X.FL coaxial socket
     - 2 mm segment of 1.5 mm OD, 0.5 mm ID silicone tubing for strain relief. The
       easiest and cheapest way to get this is by striping the silicon jacket
       from a 24 AWG flexible hookup wire.


### PR DESCRIPTION
Add part number for the X.FL connector to be soldered on the copper board.

I might be confusing the two. I was lost a bit by the use of "X.FL sockets" and "X.FL connectors". I was expecting both sides to be "connectors" and the socket to be the receptacle part (R-SMT-1) but it seems to refer to the plug (PR-SMT1-2). It does not help that hirose calls it "plug receptacle" as opposed to the "receptacle". 

If I understood correctly, I would suggest to use "plug" or "plug receptacle" instead of socket on this page.