### PR TITLE
rmv hw compatibility table

### DIFF
--- a/source/Hardware Guide/index.rst
+++ b/source/Hardware Guide/index.rst
@@ -7,10 +7,6 @@
 ==========================================
 ONIX consists of several hardware devices:
 
-.. attention:: ONIX hardware version compatibility
-    is documented on `this google sheet
-    <https://docs.google.com/spreadsheets/d/1LwEOlOkL_HJKeTmNJFVIlItzVeCZDzOt_9Up_rA36Ic/edit?usp=sharing>`_.
-
 .. toctree::
     :maxdepth: 1
     :hidden:


### PR DESCRIPTION
This table is for the old beta devices, and no longer in use. It is confusing to keep it.