### PR TITLE
Add redirects for all pages that were moved

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -47,9 +47,8 @@ extensions = [
     'sphinxext.rediraffe'
 ]
 
-rediraffe_redirects = {
-    'Hardware Guide/PCIe Host/index': 'Hardware Guide/PCIe Controller/index'
-}
+rediraffe_redirects = 'redirects.txt'
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
 

--- a/source/redirects.txt
+++ b/source/redirects.txt
@@ -1,0 +1,7 @@
+'Hardware Guide/PCIe Host/index' 'Hardware Guide/PCIe Controller/index'
+'Hardware Guide/PCIe Host/bracket-assembly' 'Hardware Guide/PCIe Controller/bracket-assembly'
+'Hardware Guide/PCIe Host/multi-board-sync' 'Hardware Guide/PCIe Controller/multi-board-sync'
+'Hardware Guide/PCIe Host/overview' 'Hardware Guide/PCIe Controller/overview'
+'Hardware Guide/PCIe Host/programming-with-jtag' 'Hardware Guide/PCIe Controller/programming-with-jtag'
+'Hardware Guide/PCIe Host/setup-windows' 'Hardware Guide/PCIe Controller/setup-windows'
+'Hardware Guide/PCIe Host/updating-gateware' 'Hardware Guide/PCIe Controller/updating-gateware'


### PR DESCRIPTION
In PR #136, the `PCIe Host` folder was renamed to `PCIe Controller`. In previous PRs (#145 and #146), only one of these pages was redirected. This PR now redirects all of the pages in that folder, so that anywhere that is referencing the old link is no longer broken (for example, the ONIX Source plugin [docs](https://open-ephys.github.io/gui-docs/User-Manual/Plugins/Onix-Source.html#plugin-configuration)).